### PR TITLE
Revised Japanese locale file & fixed several i18n issues

### DIFF
--- a/components/ReportModal.vue
+++ b/components/ReportModal.vue
@@ -6,7 +6,7 @@
       </p>
     </header>
     <section class="modal-card-body">
-      <b-field label="Reason">
+      <b-field :label="$t('Report.reason')">
         <b-radio v-model="report.reason" native-value="duplicate">
           {{ $t('Report.reasonDuplicate') }}
         </b-radio>

--- a/components/StatsTable.vue
+++ b/components/StatsTable.vue
@@ -43,7 +43,7 @@
           <td>&yen; {{ stats.average_price }}</td>
         </tr>
         <tr>
-          <th>{{ $t('Statistics.averagepages') }}</th>
+          <th>{{ $t('Statistics.averagePages') }}</th>
           <td>{{ stats.average_pages.toLocaleString() }}</td>
         </tr>
         <tr>

--- a/locales/en.json
+++ b/locales/en.json
@@ -52,6 +52,7 @@
     "buttonText": "Report",
     "title": "Report",
     "notes": "Notes",
+    "reason": "Reason",
     "reasonDuplicate": "Duplicate",
     "reasonSpam": "Spam",
     "reasonRemoval": "Removal request",
@@ -76,7 +77,7 @@
     "title": "Doujinshi.info"
   },
   "PageEditBook": {
-    "title": "Edit doujin"
+    "title": "Edit doujinshi"
   },
   "PageChangelog": {
     "title": "Changelog"
@@ -331,7 +332,8 @@
         "event_start": "Start Date",
         "event_end": "End Date",
         "description_english": "English Description",
-        "description_japanese": "Japanese Description"
+        "description_japanese": "Japanese Description",
+        "links": "Links"
       }
     }
   },

--- a/locales/ja.json
+++ b/locales/ja.json
@@ -1,13 +1,13 @@
 {
   "Common": {
     "cancel": "キャンセル",
-    "clear": "晴れ",
+    "clear": "クリア",
     "close": "閉じる",
     "edit": "編集",
     "more": "もっと",
     "no": "いいえ",
-    "save": "保存する",
-    "submit": "参加する",
+    "save": "保存",
+    "submit": "登録",
     "undo": "元に戻す",
     "yes": "はい",
     "next": "次",
@@ -16,58 +16,59 @@
     "currentPage": "現在のページ",
     "createdAt": "作成日",
     "updatedAt": "最終更新日",
-    "tag": "鬼ごっこ",
+    "tag": "タグ",
     "type": "タイプ"
   },
   "Meta": {
     "Description": {
-      "viewDoujin": "{artist}が作成した同人誌「{book}」に関する情報。",
-      "viewTag": "{type}{tag}に関連付けられている同人誌に関する情報。",
+      "viewDoujin": "{artist}の同人誌「{book}」に関する情報。",
+      "viewTag": "{type}「{tag}」に関連付けられている同人誌に関する情報。",
       "statistics": "Doujinshi.infoデータベース全体の統計情報"
     }
   },
   "Navigation": {
-    "about": "約",
+    "about": "概要",
     "account": "アカウント",
-    "accountFollowing": "フォローする",
-    "accountLibrary": "文庫",
+    "accountFollowing": "フォロー中",
+    "accountLibrary": "蔵書",
     "accountNotifications": "通知",
     "accountProfile": "プロフィール",
     "accountSettings": "設定",
     "accountWishlist": "ウィッシュリスト",
     "changelog": "変更ログ",
-    "contribute": "寄稿",
-    "contributeDoujinshi": "同人誌を作成する",
-    "contributeImport": "輸入同人誌",
-    "contributeTag": "タグを作成する",
+    "contribute": "貢献",
+    "contributeDoujinshi": "同人誌の登録",
+    "contributeImport": "同人誌のインポート",
+    "contributeTag": "タグの作成",
     "home": "ホーム",
     "login": "ログイン",
     "logout": "ログアウト",
-    "search": "サーチ",
-    "signup": "登録",
+    "search": "検索",
+    "signup": "サインアップ",
     "statistics": "統計",
     "tags": "タグ"
   },
   "Report": {
-    "buttonText": "報告する",
+    "buttonText": "報告",
     "title": "報告する",
-    "notes": "ノート",
-    "reasonDuplicate": "複製",
+    "notes": "報告の詳細",
+    "reason": "理由",
+    "reasonDuplicate": "重複",
     "reasonSpam": "スパム",
     "reasonRemoval": "削除依頼",
-    "reasonOther": "その他の",
+    "reasonOther": "その他",
     "successMessage": "レポートを受け取りました。"
   },
   "Collection": {
-    "saveTo": "に保存...",
-    "library": "図書館",
+    "saveTo": "保存先",
+    "library": "蔵書",
     "wishlist": "ウィッシュリスト",
     "savedMessage": "コレクションに保存しました",
     "removedMessage": "コレクションから削除しました"
   },
   "Follow": {
-    "following": "以下",
-    "follow": "従う"
+    "following": "フォロー中",
+    "follow": "フォローする"
   },
   "PageFollowing": {
     "title": "フォロー中のタグ"
@@ -76,22 +77,22 @@
     "title": "Doujinshi.info"
   },
   "PageEditBook": {
-    "title": "同人を編集"
+    "title": "同人誌を編集"
   },
   "PageChangelog": {
     "title": "変更ログ"
   },
   "PageAbout": {
-    "title": "約",
-    "textOpening": "Doujinshi.infoは、同人誌と呼ばれる自費出版の作品に関するデータを含む情報データベースです。 このプロジェクトの目標は、できるだけ多くの同人誌をカタログ化し、タグ付けし、分類することです。 このコミュニティ主導のデータにより、同人誌シーン全体に関する興味深い統計を提供できます。 平均ページ数、最も一般的なテーマ、平均価格など。これに加えて、ユーザーは物理的な同人誌コレクションをカタログ化して自分の所有物を追跡したり、お気に入りのアーティストやタグをフォローして新しく発見したりできます。 同人誌をリリースしました。",
+    "title": "概要",
+    "textOpening": "Doujinshi.infoは、同人誌と呼ばれる自費出版の作品に関するデータを含む情報データベースです。 このプロジェクトの目標は、できるだけ多くの同人誌をカタログ化し、タグ付けし、分類することです。 このコミュニティ主導のデータにより、平均ページ数、最も一般的なテーマ、平均価格など、同人誌シーン全体に関する興味深い統計を提供できます。 これに加えて、ユーザーは物理的な同人誌コレクションをカタログ化して自分の所有物を把握したり、お気に入りの作家やタグをフォローして新しく発行された同人誌を発見したりできます。 ",
     "textDisclaimer": "このサイトの目標は純粋に学術的なものであり、ここに掲載されている同人誌をダウンロードする機能は提供していません。 同人誌に関する情報と統計のみを提供します。",
     "featureCommunity": {
       "title": "コミュニティ",
-      "text": "Doujinshi.infoはコミュニティ主導のプロジェクトです。 ユーザーは、アップロード、タグ付け、および分類により、情報データベースへの貢献を支援します。"
-    },
-    "featureOpenSource": {
+"text": "Doujinshi.infoはコミュニティ主導のプロジェクトです。 ユーザーは、情報のアップロード、タグ付け、および分類により、データベースへ貢献します。"
+},
+"featureOpenSource": {
       "title": "オープンソース",
-      "text": "Doujinshi.infoはオープンソースプロジェクトであり、コミュニティがコードへの貢献を支援できるようにします。 リポジトリは<a href=\"https://github.com/doujinshi-info/frontend-nuxt\">doujinshi-info/frontend-nuxt</a>のGithubでホストされています。"
+      "text": "Doujinshi.infoはオープンソースプロジェクトであり、コミュニティがコードへ貢献できるようにしています。 リポジトリはGithubの<a href=\"https://github.com/doujinshi-info/frontend-nuxt\">doujinshi-info/frontend-nuxt</a>でホストされています。"
     },
     "featurePiracy": {
       "title": "海賊行為なし",
@@ -104,64 +105,64 @@
     "username": "ユーザー名",
     "email": "Eメール",
     "password": "パスワード",
-    "confirmPassword": "パスワードを認証する",
-    "loginLink": "すでに登録？ ログインする",
-    "signUpButton": "アカウントを作成する"
+    "confirmPassword": "パスワードの確認",
+    "loginLink": "登録済ですか？ ログイン",
+    "signUpButton": "アカウントを作成"
   },
   "PageSignIn": {
-    "title": "ログインする",
+    "title": "ログイン",
     "email": "Eメール",
     "password": "パスワード",
-    "forgotPasswordLink": "パスワードをお忘れですか",
-    "loginButton": "ログインする"
+    "forgotPasswordLink": "パスワードをお忘れですか?",
+    "loginButton": "ログイン"
   },
   "PageForgotPassword": {
-    "title": "パスワードをお忘れですか",
+    "title": "パスワードの再設定",
     "email": "Eメール",
     "newPassword": "新しいパスワード",
-    "confirmNewPassword": "新しいパスワードを確認",
+    "confirmNewPassword": "新しいパスワードの確認",
     "returnLink": "ログインに戻る",
-    "resetPasswordButton": "パスワードを再設定する",
-    "passwordRequestMessage": "パスワードのリセットリクエストが処理されました。 メールの受信トレイを確認してください。",
+    "resetPasswordButton": "パスワードを再設定",
+    "passwordRequestMessage": "パスワード再設定のリクエストが処理されました。 メールを確認してください。",
     "passwordChangedMessage": "あなたのパスワードは変更されました。"
   },
   "PageUserProfile": {
-    "dateJoined": "加入日",
-    "libraryEstimatedValue": "推定値",
+    "dateJoined": "登録日",
+    "libraryEstimatedValue": "蔵書の見積もり価値",
     "contributions": "貢献",
-    "library": "図書館",
+    "library": "蔵書",
     "wishlist": "ウィッシュリスト"
   },
   "ProfileTab": {
     "information": "情報",
-    "library": "図書館",
+    "library": "蔵書",
     "wishlist": "ウィッシュリスト",
     "contributions": "貢献"
   },
   "PageStatistics": {
-    "title": "統計学"
+    "title": "統計"
   },
   "PageTags": {
     "title": "タグ",
-    "tag": "鬼ごっこ",
+    "tag": "タグ",
     "type": "タイプ"
   },
   "PageCreateDoujin": {
-    "title": "同人誌に寄稿"
+    "title": "同人誌を登録"
   },
   "PageEditTag": {
     "title": "タグを編集"
   },
   "PageCreateTag": {
-    "title": "投稿タグ"
+    "title": "タグを登録"
   },
   "PageAccountSettings": {
     "title": "アカウント設定",
     "profileInformation": "プロフィール情報",
     "profilePrivacy": "プロフィールのプライバシー",
-    "public": "公衆",
-    "private": "民間",
-    "securityTitle": "安全保障",
+    "public": "公開",
+    "private": "非公開",
+    "securityTitle": "セキュリティ",
     "currentPassword": "現在のパスワード",
     "newPassword": "新しいパスワード",
     "confirmNewPassword": "新しいパスワードを確認",
@@ -170,11 +171,11 @@
     "email": "Eメール"
   },
   "PageAccountNotifications": {
-    "title": "お知らせ",
+    "title": "通知",
     "noResults": "通知は見つかりませんでした",
     "markAllRead": "すべて既読にする",
     "desktopNotifications": "このブラウザで通知を受け取る",
-    "newDoujinText": "フォローしている{tag}タグに新しい同人誌が追加されました：{book}。"
+    "newDoujinText": "フォロー中のタグ「{tag}」に新しい同人誌「{book}」が追加されました。"
   },
   "PageImportDoujinshi": {
     "title": "インポート",
@@ -182,101 +183,101 @@
     "importSuccessMessage": "インポートジョブが正常にスケジュールされました。"
   },
   "Statistics": {
-    "totalDoujinshi": "総同人誌",
-    "totalTags": "合計タグ",
-    "totalCircles": "合計サークル",
-    "totalArtists": "アーティスト総数",
-    "totalContents": "合計内容",
-    "totalSeries": "総シリーズ",
-    "totalCharacters": "総文字数",
-    "totalConventions": "総大会",
-    "totalCollections": "総コレクション",
-    "totalUsers": "総ユーザー",
+    "totalDoujinshi": "総同人誌数",
+    "totalTags": "総タグ数",
+    "totalCircles": "総サークル数",
+    "totalArtists": "総作家数",
+    "totalContents": "総コンテンツ数",
+    "totalSeries": "総シリーズ数",
+    "totalCharacters": "総キャラクター数",
+    "totalConventions": "総イベント数",
+    "totalCollections": "総コレクション数",
+    "totalUsers": "総ユーザー数",
     "averagePrice": "平均価格",
     "averagePages": "平均ページ数",
     "originalRatio": "オリジナル：パロディー比",
-    "mostWorksArtists": "アーティストによるほとんどの作品",
-    "mostWorksCircle": "ほとんどの作品はサークル",
-    "mostWorksConvention": "ほとんどは慣例で動作します",
+    "mostWorksArtists": "最も一般的な作家",
+    "mostWorksCircle": "最も一般的なサークル",
+    "mostWorksConvention": "最も一般的なイベント",
     "commonSeries": "最も一般的なシリーズ",
-    "commonCharacters": "最も一般的な文字",
+    "commonCharacters": "最も一般的なキャラクター",
     "commonContent": "最も一般的なコンテンツ",
     "contributions": "貢献"
   },
   "Filter": {
     "buttonText": "フィルタ",
-    "releaseDate": "発売日",
+    "releaseDate": "発行日",
     "releaseDatePlaceholder": "クリックして日付範囲を選択..."
   },
   "Doujin": {
-    "titleOriginal": "元のタイトル",
+    "titleOriginal": "オリジナルタイトル",
     "titleRomaji": "ローマ字タイトル",
     "titleEnglish": "英語タイトル",
-    "releaseDate": "発売日",
+    "releaseDate": "発行日",
     "price": "価格",
     "pages": "ページ",
-    "isAdult": "成人コンテンツ",
+    "isAdult": "成人向け",
     "isAnthology": "アンソロジー",
-    "isCopybook": "コピーブック",
+    "isCopybook": "コピー本",
     "isNovel": "小説",
     "language": "言語",
     "censoring": "検閲",
-    "convention": "コンベンション",
-    "artists": "アーティスト",
+    "convention": "イベント",
+    "artists": "作家",
     "circles": "サークル",
     "series": "シリーズ",
     "characters": "キャラクター",
     "content": "コンテンツ",
-    "links": "リンク集",
+    "links": "リンク",
     "images": "画像",
     "cover": "表紙画像",
     "samples": "サンプル画像",
     "imageUploadMessage": "画像ファイルを選択",
     "imageUploadErrorSize": "ファイルのサイズは5MBを超えないようにしてください",
-    "imageUploadErrorType": "無効なファイルタイプ。 画像のみ許可されています",
+    "imageUploadErrorType": "無効なファイルタイプ。 画像ファイルのみ許可されています",
     "imageUploadDeleteConfirm": "この画像を削除してもよろしいですか？"
   },
   "TagTabs": {
     "information": "情報",
-    "statistics": "統計学",
+    "statistics": "統計",
     "changelog": "変更ログ"
   },
   "Tag": {
     "type": "タイプ",
     "typePlaceholder": "タイプを選択...",
-    "nameOriginal": "元の名前",
+    "nameOriginal": "オリジナル名",
     "nameRomaji": "ローマ字名",
     "nameEnglish": "英語名",
     "nameAliases": "他の名前",
     "eventDates": "イベント日程",
     "descriptionEnglish": "説明（英語）",
     "descriptionJapanese": "説明（日本語）",
-    "artists": "アーティスト",
+    "artists": "作家",
     "circles": "サークル",
     "series": "シリーズ",
-    "links": "リンク集"
+    "links": "リンク"
   },
   "TagTypes": {
-    "artist": "アーティスト",
+    "artist": "作家",
     "circle": "サークル",
     "character": "キャラクター",
     "content": "コンテンツ",
     "series": "シリーズ",
-    "convention": "コンベンション",
+    "convention": "イベント",
     "language": "言語",
     "collection": "コレクション"
   },
   "Links": {
     "toranoana": "とらのあな",
-    "pixiv": "ピクシブ",
+    "pixiv": "pixiv",
     "melonbooks": "メロンブックス",
-    "boothpm": "Booth.pm",
-    "twitter": "ツイッター",
+    "boothpm": "BOOTH",
+    "twitter": "Twitter",
     "circlems": "Circle.ms",
-    "amazon": "アマゾン",
-    "patreon": "パトレオン",
+    "amazon": "Amazon",
+    "patreon": "Patreon",
     "enty": "Enty",
-    "fantia": "ファンティア",
+    "fantia": "Fantia",
     "alice": "アリスブックス",
     "dlsite": "DLsite",
     "dmm": "DMM / FANZA"
@@ -285,44 +286,44 @@
     "transaction": "トランザクション",
     "object": "オブジェクト",
     "operation": "操作",
-    "create": "創作",
+    "create": "作成",
     "update": "更新",
     "delete": "削除",
-    "contributor": "寄稿者",
-    "amount": "量",
-    "differences": "違い",
+    "contributor": "貢献者",
+    "amount": "サイズ",
+    "differences": "差分",
     "data": "データ",
     "oldValue": "古い値",
-    "newValue": "新しい価値",
+    "newValue": "新しい価",
     "noChanges": "変更は見つかりませんでした",
-    "tag": "鬼ごっこ",
+    "tag": "タグ",
     "doujinshi": "同人誌",
     "type": "タイプ",
     "noResults": "変更は見つかりませんでした",
     "diff": {
       "book": {
-        "slug": "ナメクジ",
-        "name_original": "元のタイトル",
+        "slug": "スラッグ",
+        "name_original": "オリジナルタイトル",
         "name_romaji": "ローマ字タイトル",
         "name_english": "英語タイトル",
-        "release_date": "発売日",
-        "date_released": "発売日",
+        "release_date": "発行日",
+        "date_released": "発行日",
         "language": "言語",
         "censoring": "検閲",
         "price": "価格（円）",
         "pages": "ページ",
-        "convention": "コンベンション",
+        "convention": "イベント",
         "is_novel": "小説",
-        "is_adult": "成人コンテンツ",
-        "is_copybook": "コピーブック",
+        "is_adult": "成人向け",
+        "is_copybook": "コピー本",
         "is_anthology": "アンソロジー",
         "cover": "表紙画像",
         "samples": "サンプル画像",
-        "links": "リンク集"
+        "links": "リンク"
       },
       "tag": {
-        "slug": "ナメクジ",
-        "name_original": "元の名前",
+        "slug": "スラッグ",
+        "name_original": "オリジナル名",
         "name_romaji": "ローマ字名",
         "name_english": "英語名",
         "name_other": "他の名前",
@@ -330,24 +331,25 @@
         "event_dates": "イベント日程",
         "event_start": "開始日",
         "event_end": "終了日",
-        "description_english": "英語の説明",
-        "description_japanese": "日本語の説明"
+        "description_english": "説明 (英語)",
+        "description_japanese": "説明 (日本語)",
+        "links": "リンク"
       }
     }
   },
   "PageSearchResults": {
-    "title": "の検索結果"
+    "title": "検索結果"
   },
   "Search": {
-    "placeholder": "探す...",
+    "placeholder": "検索...",
     "type": {
-      "doujin": "同人",
-      "artist": "アーティスト",
+      "doujin": "同人誌",
+      "artist": "作家",
       "circle": "サークル",
       "character": "キャラクター",
       "content": "コンテンツ",
       "series": "シリーズ",
-      "convention": "コンベンション"
+      "convention": "イベント"
     },
     "noResults": "結果が見つかりません"
   },
@@ -355,22 +357,22 @@
     "image_no_results":"結果が見つかりません。",
     "general":"エラーが発生しました。 もう一度お試しください。",
     "access_denied":"アクセスが拒否されました。",
-    "access_token_missing":"アクセス・トークンが無効です。",
-    "refresh_token_expired":"リフレッシュ・トークンが失効しました。",
+    "access_token_missing":"アクセストークンが無効です。",
+    "refresh_token_expired":"リフレッシュトークンが失効しました。",
     "reset_invalid":"パスワードリセット要求が無効です。",
     "cannot_revert":"最初の作成を元に戻すことはできません。 削除リクエストを送信してください。",
-    "rate_limit":"もう一度試してください。",
+    "rate_limit":"数分後にもう一度試してください。",
     "notification_invalid":"通知は無効です。",
     "notification":{
       "required":"通知がありません。"
     },
     "book":{
-      "required":"予約不足"
+      "required":"本がありません"
     },
     "user":{
       "invalid":"申し訳ありませんが、これらの資格情報を持つアカウントを見つけることができませんでした。",
-      "required":"ユーザーがいない",
-      "banned":"申し訳ありませんが、このアカウントは禁止されています。"
+      "required":"ユーザーがありません。",
+      "banned":"申し訳ありませんが、このアカウントはアクセス禁止されています。"
     },
     "refresh_token":{
       "required":"リフレッシュトークンが必要です。"
@@ -381,113 +383,113 @@
       "alpha_num":"名前に使用できるのは英数字のみです。"
     },
     "email":{
-      "required":"電子メールフィールドは必須です。",
-      "invalid":"指定されたメールは無効な形式です。",
+      "required":"Eメール欄は必須です。",
+      "invalid":"指定されたメールアドレスは無効な形式です。",
       "unique":"このメールアドレスはすでに登録されています。"
     },
     "password":{
-      "required":"パスワードフィールドは必須です。",
+      "required":"パスワード欄は必須です。",
       "confirm":"パスワードの確認が一致しません。",
-      "required_with":"パスワードフィールドは必須です。"
+      "required_with":"パスワード欄は必須です。"
     },
     "new_password":{
-      "required_with":"新しいパスワードフィールドは必須です。",
+      "required_with":"新しいパスワード欄は必須です。",
       "confirmation":""
     },
     "password_confirmation":{
-      "required":"パスワード確認フィールドは必須です。"
+      "required":"パスワード確認欄は必須です。"
     },
     "name_japanese":{
-      "required":"元の名前/タイトルフィールドは必須です。"
+      "required":"オリジナル名/タイトル欄は必須です。"
     },
     "date_released":{
-      "invalid":"リリースされた日付の日付は無効です。"
+      "invalid":"リリースされた日付は無効です。"
     },
     "pages":{
-      "numeric":"ページフィールドは数字でなければなりません。"
+      "numeric":"ページ欄は数字でなければなりません。"
     },
     "price":{
-      "numeric":"価格フィールドは数字でなければなりません。"
+      "numeric":"価格欄は数字でなければなりません。"
     },
     "is_copybook":{
-      "bool":"コピーブックセクションは、はいまたはいいえのみにすることができます。"
+      "bool":"コピー本は、「はい」か「いいえ」のどちらかを選択してください。"
     },
     "is_anthology":{
-      "bool":"アンソロジーセクションは、「はい」または「いいえ」のみにすることができます。"
+      "bool":"アンソロジーは、「はい」か「いいえ」のどちらかを選択してください。"
     },
     "is_adult":{
-      "bool":"大人のセクションは、「はい」または「いいえ」のみにすることができます。"
+      "bool":"成人向けは、「はい」か「いいえ」のどちらかを選択してください。"
     },
     "is_novel":{
-      "bool":"斬新なセクションは、イエスかノーのみであることができます。"
+      "bool":"小説は、「はい」か「いいえ」のどちらかを選択してください。"
     },
     "cover":{
-      "image":"カバーファイルはイメージでなければなりません。",
-      "max":"カバーファイルは、許可されている最大ファイルサイズよりも大きいです。"
+      "image":"表紙ファイルは画像ファイルでなければなりません。",
+      "max":"表紙ファイルは、許可されている最大ファイルサイズを超えています。"
     },
     "samples":{
-      "image":"サンプルファイルはイメージでなければなりません。",
+      "image":"サンプルファイルは画像ファイルでなければなりません。",
       "max":"サンプルファイルは、許可されている最大ファイルサイズを超えています。"
     },
     "links":{
       "invalid":"送信されたリンクは無効です。",
       "toranoana":{
-         "invalid":"Toranoanaへの提出されたリンクは無効です。"
+         "invalid":"入力されたとらのあなのリンクが無効です。"
       },
       "pixiv":{
-         "invalid":"Pixivへの提出されたリンクは無効です。"
+         "invalid":"入力されたpixivのリンクが無効です。"
       },
       "twitter":{
-         "invalid":"Twitterへの送信されたリンクが無効です。"
+         "invalid":"入力されたTwitterのリンクが無効です。"
       },
       "melonbooks":{
-         "invalid":"メロンブックへの提出されたリンクは無効です。"
+         "invalid":"入力されたメロンブックスのリンクが無効です。"
       },
       "boothpm":{
-         "invalid":"Booth.pmへの提出されたリンクは無効です。"
+         "invalid":"入力されたBOOTHのリンクが無効です。"
       },
       "amazon":{
-         "invalid":"Amazonへの提出されたリンクが無効です。"
+         "invalid":"入力されたAmazonのリンクが無効です。"
       }
     },
     "url":{
-      "required":"urlフィールドは必須です。"
+      "required":"url欄は必須です。"
     },
     "content_type":{
-      "required":"タイプフィールドは必須です。"
+      "required":"タイプ欄は必須です。"
     },
     "content":{
       "required":"内容は必須です。"
     },
     "reason":{
-      "required":"理由フィールドは必須です。",
-      "max":"理由テキストの文字数が多すぎます。"
+      "required":"理由欄は必須です。",
+      "max":"理由欄の文字数が多すぎます。"
     },
     "status":{
-      "required":"ステータスフィールドは必須です。"
+      "required":"ステータス欄は必須です。"
     },
     "transaction_id":{
       "required":"トランザクション値がありません。"
     },
     "image":{
       "required":"画像が必要です。",
-      "invalid":"イメージはイメージでなければなりません。",
-      "max":"画像が許可されているファイルサイズを超えています。"
+      "invalid":"画像は画像ファイルでなければなりません。",
+      "max":"画像ファイルが許可されているファイルサイズを超えています。"
     },
     "type":{
-      "required":"タイプフィールドは必須です。"
+      "required":"タイプ欄は必須です。"
     },
     "description_english":{
-      "max":"英語の説明の長さが長すぎます。"
+      "max":"説明 (英語) の長さが長すぎます。"
     },
     "description_japanese":{
-      "max":"日本語の説明の長さが長すぎます。"
+      "max":"説明 (日本語) の長さが長すぎます。"
     },
     "date_start":{
       "invalid":"開始日が無効です。"
     },
     "date_end":{
-      "invalid":"終了日は無効です。"
+      "invalid":"終了日が無効です。"
     }
   }
 }

--- a/pages/account/following.vue
+++ b/pages/account/following.vue
@@ -28,7 +28,7 @@
       :aria-next-label="$t('Common.next')"
       :aria-previous-label="$t('Common.prev')"
       :aria-page-label="$t('Common.page')"
-      :aria-current-label="$t('Common.currentpage')"
+      :aria-current-label="$t('Common.currentPage')"
       @change="onPageChange"
     >
       <b-pagination-button

--- a/pages/account/notifications.vue
+++ b/pages/account/notifications.vue
@@ -39,7 +39,7 @@
               <div class="content">
                 <span v-if="notification.type == 'new_doujin'">
                   {{
-                    $t(`PageAccountNotifications.newDoujin`, {
+                    $t(`PageAccountNotifications.newDoujinText`, {
                       tag: getLocalizedName(notification.tag.name),
                       book: getLocalizedName(notification.book.name)
                     })

--- a/pages/tag/_type/index.vue
+++ b/pages/tag/_type/index.vue
@@ -108,7 +108,7 @@ export default {
   },
   head () {
     return {
-      title: this.$t('PageTags.title') + ' : ' + this.$t('tagTypes.' + this.tagType)
+      title: this.$t('PageTags.title') + ' : ' + this.$t('TagTypes.' + this.tagType)
     }
   }
 }


### PR DESCRIPTION
- entirely revised Japanese translation of locales/ja.json
- fixed i18n keys in several .vue files
- fixed an un-i18ed text ('Reason') in components/ReportModal.vue
- added lacking keys to locales/{en,ja}.json